### PR TITLE
Fixed unpredictable relative file path in gizmo knobs.

### DIFF
--- a/LensKernelFFT.gizmo
+++ b/LensKernelFFT.gizmo
@@ -14,7 +14,7 @@ Gizmo {
 }
  Read {
   inputs 0
-  file "[python os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'LensKernelFFT', '35mmf56_normalized_v01.exr'))]"
+  file ""
   format "3908 2602 0 0 3908 2602 1 "
   origset true
   name Read3
@@ -23,7 +23,7 @@ Gizmo {
  }
  Read {
   inputs 0
-  file "[python os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'LensKernelFFT', '35mmf28_normalized_v01.exr'))]"
+  file ""
   format "3908 2602 0 0 3908 2602 1 "
   origset true
   name Read2
@@ -32,7 +32,7 @@ Gizmo {
  }
  Read {
   inputs 0
-  file "[python os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'LensKernelFFT', '35mmf14_normalized_v01.exr'))]"
+  file ""
   format "3908 2602 0 0 3908 2602 1 "
   origset true
   name Read1

--- a/localizeLensKernel.py
+++ b/localizeLensKernel.py
@@ -3,6 +3,9 @@ Created by Jeang Jenq Loh on 24/10/2019
 Created to work with LensKernelFFT gizmo
 http://www.nukepedia.com/gizmos/filter/lenskernelfft_v01/finishdown?miv=1&mjv=1
 Copies the kernel files to the script directory for easy access
+
+Update 05/11/2019
+Fixed file path issue and now convert to absolute path oncreate
 '''
 
 import nuke
@@ -19,8 +22,8 @@ kernels_knobs = ['kernel14',
 
 def localizeLensKernel():
     script_dir = os.path.dirname(nuke.Root().name())
+    this = nuke.thisNode()
     if script_dir is not '':
-        this = nuke.thisNode()
         index = 0
         # Copy kernel files to script directory
         for kernel in kernels:
@@ -40,5 +43,11 @@ def localizeLensKernel():
         for node in nuke.allNodes(group=this):
             if node.Class() == 'Read':
                 node['reload'].execute()
+    else:
+        index = 0
+        for kernel in kernels:
+            old_file = os.path.abspath(current_dir + kernel)
+            this[kernels_knobs[index]].setValue(old_file)
+            index += 1
 
 nuke.addOnUserCreate(localizeLensKernel, nodeClass='LensKernelFFT')


### PR DESCRIPTION
The use of `__file__` in knob is unpredictable since it'll return the file path of last imported python file. To fix this,

1. Moved `__file__` to localizeLensKernel.py for it to be part of `onCreate`.
2. If nuke script is not saved, `onCreate` will now set absolute file paths for kernels.
3. If nuke script is saved, `onCreate` will copy the kernel files to the script folder, and set the knobs paths relative to script folder.